### PR TITLE
Fixed crash with Android bigger then Oreo. TYPE_PHONE, TYPE_SYSTEM_OVERLAY is deprecated after 26 target sdk. Need use TYPE_APPLICATION_OVERLAY

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         applicationId "com.txusballesteros.bubbles.app"
         minSdkVersion 14
-        targetSdkVersion 22
+        targetSdkVersion 27
         versionCode 1
         versionName parent.ext.libraryVersion
     }
@@ -21,6 +21,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.2.0'
+    compile 'com.android.support:appcompat-v7:27.0.2'
     compile project(':bubbles')
 }

--- a/app/src/main/java/com/txusballesteros/bubbles/app/MainActivity.java
+++ b/app/src/main/java/com/txusballesteros/bubbles/app/MainActivity.java
@@ -25,7 +25,7 @@
 package com.txusballesteros.bubbles.app;
 
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Toast;
@@ -34,7 +34,7 @@ import com.txusballesteros.bubbles.BubbleLayout;
 import com.txusballesteros.bubbles.BubblesManager;
 import com.txusballesteros.bubbles.OnInitializedCallback;
 
-public class MainActivity extends ActionBarActivity {
+public class MainActivity extends AppCompatActivity {
 
     private BubblesManager bubblesManager;
 
@@ -54,10 +54,11 @@ public class MainActivity extends ActionBarActivity {
     }
 
     private void addNewBubble() {
-        BubbleLayout bubbleView = (BubbleLayout)LayoutInflater.from(MainActivity.this).inflate(R.layout.bubble_layout, null);
+        BubbleLayout bubbleView = (BubbleLayout) LayoutInflater.from(MainActivity.this).inflate(R.layout.bubble_layout, null);
         bubbleView.setOnBubbleRemoveListener(new BubbleLayout.OnBubbleRemoveListener() {
             @Override
-            public void onBubbleRemoved(BubbleLayout bubble) { }
+            public void onBubbleRemoved(BubbleLayout bubble) {
+            }
         });
         bubbleView.setOnBubbleClickListener(new BubbleLayout.OnBubbleClickListener() {
 
@@ -73,14 +74,14 @@ public class MainActivity extends ActionBarActivity {
 
     private void initializeBubblesManager() {
         bubblesManager = new BubblesManager.Builder(this)
-                                    .setTrashLayout(R.layout.bubble_trash_layout)
-                                    .setInitializationCallback(new OnInitializedCallback() {
-                                        @Override
-                                        public void onInitialized() {
-                                            addNewBubble();
-                                        }
-                                    })
-                                    .build();
+                .setTrashLayout(R.layout.bubble_trash_layout)
+                .setInitializationCallback(new OnInitializedCallback() {
+                    @Override
+                    public void onInitialized() {
+                        addNewBubble();
+                    }
+                })
+                .build();
         bubblesManager.initialize();
     }
 

--- a/bubbles/build.gradle
+++ b/bubbles/build.gradle
@@ -11,12 +11,12 @@ Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 22
+        targetSdkVersion 27
         versionCode 1
         versionName version
     }

--- a/bubbles/src/main/java/com/txusballesteros/bubbles/BubblesLayoutCoordinator.java
+++ b/bubbles/src/main/java/com/txusballesteros/bubbles/BubblesLayoutCoordinator.java
@@ -24,8 +24,6 @@
  */
 package com.txusballesteros.bubbles;
 
-import android.content.Context;
-import android.os.Vibrator;
 import android.view.View;
 import android.view.WindowManager;
 

--- a/bubbles/src/main/java/com/txusballesteros/bubbles/BubblesService.java
+++ b/bubbles/src/main/java/com/txusballesteros/bubbles/BubblesService.java
@@ -27,8 +27,8 @@ package com.txusballesteros.bubbles;
 import android.app.Service;
 import android.content.Intent;
 import android.graphics.PixelFormat;
-import android.graphics.Point;
 import android.os.Binder;
+import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
@@ -36,7 +36,6 @@ import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.WindowManager;
-import android.widget.FrameLayout;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -80,7 +79,7 @@ public class BubblesService extends Service {
 
     private WindowManager getWindowManager() {
         if (windowManager == null) {
-            windowManager = (WindowManager)getSystemService(WINDOW_SERVICE);
+            windowManager = (WindowManager) getSystemService(WINDOW_SERVICE);
         }
         return windowManager;
     }
@@ -123,10 +122,15 @@ public class BubblesService extends Service {
     }
 
     private WindowManager.LayoutParams buildLayoutParamsForBubble(int x, int y) {
+        int typeOverlay = WindowManager.LayoutParams.TYPE_PHONE;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            typeOverlay = WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
+        }
+
         WindowManager.LayoutParams params = new WindowManager.LayoutParams(
                 WindowManager.LayoutParams.WRAP_CONTENT,
                 WindowManager.LayoutParams.WRAP_CONTENT,
-                WindowManager.LayoutParams.TYPE_PHONE,
+                typeOverlay,
                 WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
                 PixelFormat.TRANSPARENT);
         params.gravity = Gravity.TOP | Gravity.START;
@@ -138,10 +142,16 @@ public class BubblesService extends Service {
     private WindowManager.LayoutParams buildLayoutParamsForTrash() {
         int x = 0;
         int y = 0;
+
+        int typeOverlay = WindowManager.LayoutParams.TYPE_SYSTEM_OVERLAY;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            typeOverlay = WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
+        }
+
         WindowManager.LayoutParams params = new WindowManager.LayoutParams(
                 WindowManager.LayoutParams.MATCH_PARENT,
                 WindowManager.LayoutParams.MATCH_PARENT,
-                WindowManager.LayoutParams.TYPE_SYSTEM_OVERLAY,
+                typeOverlay,
                 WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
                 PixelFormat.TRANSPARENT);
         params.x = x;

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,10 @@ buildscript {
             url "https://oss.sonatype.org/content/repositories/snapshots/"
         }
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
         classpath 'com.github.dcendents:android-maven-plugin:1.2'
     }
@@ -23,5 +24,6 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }


### PR DESCRIPTION
Fixed crash with Android bigger then Oreo. TYPE_PHONE, TYPE_SYSTEM_OVERLAY is deprecated after 26 target sdk. Need use TYPE_APPLICATION_OVERLAY. Update build gradle plugin, support library. Updated target SDK, compile SDK. Issue reproduced for target SDK 26+