### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the library dependency in your build.gradle file.
 ```groovy
 dependencies {
     ...
-    compile 'com.txusballesteros:bubbles:1.2.1'
+    implementation 'com.txusballesteros:bubbles:1.2.1'
 }
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.